### PR TITLE
added session parameter to Client init

### DIFF
--- a/netbox_pyswagger/__init__.py
+++ b/netbox_pyswagger/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Jeremy Schulman'
 

--- a/netbox_pyswagger/client.py
+++ b/netbox_pyswagger/client.py
@@ -8,9 +8,10 @@ __all__ = ['Client']
 class Client(HalutzClient):
     apidocs_url = "/api/docs?format=openapi"
 
-    def __init__(self, server_url, api_token, remote=None):
-        netbox = Session()
+    def __init__(self, server_url, api_token, session=None, remote=None):
+        netbox = session or Session()
         netbox.headers['Authorization'] = "Token %s" % api_token
+
         super(Client, self).__init__(
             server_url=server_url,
             session=netbox,


### PR DESCRIPTION
One can now pass an existing `requests.Session` instance to the Client constructor.  In this way, you can pre-setup your session; for example disable SSL checking by setting your session.verify = False. 

You do *not* need to setup your API token in your session; you still pass that in the Client constructor, and it will be assigned properly in your session.headers.