### PR TITLE
updated to use with halutz 0.3.0

### DIFF
--- a/netbox_pyswagger/__init__.py
+++ b/netbox_pyswagger/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.3'
+__version__ = '0.2.0'
 __author__ = 'Jeremy Schulman'
 

--- a/netbox_pyswagger/client.py
+++ b/netbox_pyswagger/client.py
@@ -8,24 +8,29 @@ __all__ = ['Client']
 class Client(HalutzClient):
     apidocs_url = "/api/docs?format=openapi"
 
-    def __init__(self, server_url, api_token, session=None, remote=None):
-        netbox = session or Session()
-        netbox.headers['Authorization'] = "Token %s" % api_token
+    def __init__(self, api_token, **halutz_kwargs):
+        # the api version will get set when the spec is loaded from the server
         self.api_version = None
 
-        super(Client, self).__init__(
-            server_url=server_url,
-            session=netbox,
-            remote=remote)
+        kwargs = halutz_kwargs or {}
+
+        if 'session' not in kwargs:
+            kwargs['session'] = Session()
+
+        # setup the token in the session headers
+        kwargs['session'].headers['Authorization'] = "Token %s" % api_token
+
+        # invoke the halutz initializer
+        super(Client, self).__init__(**kwargs)
 
     @classmethod
     def from_pynetbox(cls, pynb):
-        api_token = pynb.api_kwargs['token']
-        server_url = pynb.api_kwargs['base_url'].split('/api')[0]
+        kwargs = dict()
+        kwargs['api_token'] = pynb.api_kwargs['token']
+        kwargs['server_url'] = pynb.api_kwargs['base_url'].split('/api')[0]
+        kwargs['remote'] = pynb
 
-        return cls(server_url=server_url,
-                   api_token=api_token,
-                   remote=pynb)
+        return cls(**kwargs)
 
     def fetch_swagger_spec(self):
         url = "%s%s" % (self.server_url, self.apidocs_url)
@@ -42,21 +47,8 @@ class Client(HalutzClient):
 
         self.api_version = resp.headers['API-Version']
 
-        # Fix for Netbox #1853 https://github.com/digitalocean/netbox/issues/1853
-        for path in spec['paths'].keys():
-            for method in spec['paths'][path].keys():
+        if self.api_version == "2.2":
+            from .patch_2_2 import patch_spec
+            patch_spec(spec)
 
-                if 'parameters' not in spec['paths'][path][method].keys():
-                    continue
-
-                for param in spec['paths'][path][method]['parameters']:
-                    if param['in'] != 'body':
-                        continue
-                    
-                    if 'custom_fields' not in param['schema']['properties'].keys():
-                        continue
-                
-                    if param['schema']['properties']['custom_fields']['type'] == 'string':
-                        param['schema']['properties']['custom_fields']['type'] = 'object'
-                    
         return spec

--- a/netbox_pyswagger/patch_2_2.py
+++ b/netbox_pyswagger/patch_2_2.py
@@ -1,0 +1,18 @@
+
+def patch_spec(spec):
+    # Fix for Netbox #1853 https://github.com/digitalocean/netbox/issues/1853
+    for path in spec['paths'].keys():
+        for method in spec['paths'][path].keys():
+
+            if 'parameters' not in spec['paths'][path][method].keys():
+                continue
+
+            for param in spec['paths'][path][method]['parameters']:
+                if param['in'] != 'body':
+                    continue
+
+                if 'custom_fields' not in param['schema']['properties'].keys():
+                    continue
+
+                if param['schema']['properties']['custom_fields']['type'] == 'string':
+                    param['schema']['properties']['custom_fields']['type'] = 'object'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     license='MIT',
     zip_safe=False,
     install_requires=[
-        'halutz>=0.2.0',
+        'halutz>=0.3.0',
         'requests',
         'six'
     ],


### PR DESCRIPTION
you can now load/store saved swagger spec files to avoid repeated downloads.
see [halutz client.py](https://github.com/jeremyschulman/halutz/blob/master/halutz/client.py) for details.